### PR TITLE
ui/290-new 320px proportion correction

### DIFF
--- a/src/app/(main)/products/new/NewProduct.tsx
+++ b/src/app/(main)/products/new/NewProduct.tsx
@@ -105,7 +105,7 @@ export default function NewProduct() {
         <Makeproject className="w-[538px] h-[1249px]" />
       </div>
       {/* 오른쪽 내용 */}
-      <div className="flex flex-col min-w-[460px] px-6 py-6 mobile:px-10 mobile:py-10 tablet:px-[90px] tablet:py-[64px] laptop:px-[90px] laptop:py-[64px]">
+      <div className="flex flex-col min-w-[320px] px-[12px] py-[24px] mobile:px-10 mobile:py-10 tablet:px-[90px] tablet:py-[64px] laptop:px-[90px] laptop:py-[64px]">
         <div className="">
           <CreateProjectTitle
             title={
@@ -129,7 +129,11 @@ export default function NewProduct() {
         </div>
         <ProductSummaryInput />
         <div className="mt-[72px] laptop:mt-[78px]">
-          <CreateProjectTitle title="프로젝트 동의서" sub="프로젝트 등록을 위한 필수 동의 항목을 확인해주세요." />
+          <CreateProjectTitle
+            title="프로젝트 동의서"
+            sub="프로젝트 등록을 위한 필수 동의 항목을 확인해주세요."
+            gap={15}
+          />
         </div>
         <div className="flex flex-col gap-[12px] mt-[42px]">
           <PreviewCheckboxWithLabel
@@ -163,7 +167,6 @@ export default function NewProduct() {
             }}
             className="px-[32px] py-[12px] mt-[19px] medium-14 bg-secondary-200  hover:bg-primary-800  text-white "
           >
-            {/* <Link href={'new/detail'}>상세 프로젝트 등록하기</Link> */}
             상세 프로젝트 등록하기
           </button>
         </div>

--- a/src/components/button/SquareBtn.tsx
+++ b/src/components/button/SquareBtn.tsx
@@ -70,7 +70,7 @@ export function PreviewCheckboxWithLabel({ title, conditionsCheck }: PreviewChec
       <div className="flex items-center gap-2">
         <button
           type="button"
-          className={`w-[18px] h-[18px] text-secondary-200 cursor-pointer mt-[5px] hover:text-primary-800`}
+          className={`flex-shrink-0 mobile:flex-shrink-1 w-[18px] h-[18px] text-secondary-200 cursor-pointer mt-[5px] hover:text-primary-800`}
           onClick={toggle}
         >
           {checked ? <CheckBox className="w-full h-full text-primary-800" /> : <UnCheckBox className="w-full h-full" />}

--- a/src/components/term/TermsBtn.tsx
+++ b/src/components/term/TermsBtn.tsx
@@ -26,7 +26,10 @@ export function TermsAgreement({ conditionsCheck }: { conditionsCheck?: (title: 
         />
       </div>
 
-      <div onClick={() => setShowModal(true)} className="absolute right-0 top-0 mt-[4px] cursor-pointer">
+      <div
+        onClick={() => setShowModal(true)}
+        className="absolute right-0  min-[450px]:right-0 min-[450px]:top-0 mt-[4px] cursor-pointer"
+      >
         <ReadTerms />
       </div>
 


### PR DESCRIPTION
## PR 유형
- [x] CSS 등 사용자 UI 디자인 변경


## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
브런치: 290-productsnew-mobile-ui-fixed

/products/new 페이지에서 해상도가 320px 일때 UI가 깨지는 것을  수정했습니다.

## 이슈

resolves #290

